### PR TITLE
[HOTFIX] Toast width을 wrap_content로 변경

### DIFF
--- a/app/src/main/res/layout/toast_home.xml
+++ b/app/src/main/res/layout/toast_home.xml
@@ -9,8 +9,8 @@
 
     <TextView
         android:id="@+id/tv_initial_toast"
-        android:layout_width="370dp"
-        android:layout_height="40dp"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
         android:layout_weight="1"
         android:background="@drawable/bg_home_toast"
         android:text="감정 날씨가 저장 되었습니다"

--- a/app/src/main/res/layout/toast_initial.xml
+++ b/app/src/main/res/layout/toast_initial.xml
@@ -10,7 +10,7 @@
     <TextView
         android:id="@+id/tv_initial_toast"
         android:layout_width="wrap_content"
-        android:layout_height="40dp"
+        android:layout_height="0dp"
         android:layout_weight="1"
         android:background="@drawable/bg_initial_toast"
         android:text="유어웨더 회원이 되신 걸 환영합니다!"


### PR DESCRIPTION
## 개요

> Toast width을 wrap_parent로 변경

## 작업 사항

- 당연히! width를 임의의 숫자(dp)로 잡으면 깨집니다. 모든 폰의 너비가 해당 dp 만큼의 여유 공간이 있는건 아니까요! 그래서 보통 TextView의경우, wrap_content나 match_parent 등의 친구들을 씁니다!!! dp는 모든 기기를 책임지지 않아요!!!
- 한 가지 걸리는 것은, 디자인 상의 토스트가 양옆 공간이 많이 남는 걸 원해서 저렇게 dp를 박아놓은 것이라고 하신다면,, 저도 방법을 잘 모르겠습니다. 이건 한 번 더 생각해봐야 할 문제 같아요. 이상 에디 올림!

## 참고사항 및 스크린샷
<img width="249" alt="스크린샷 2023-09-07 오전 1 17 04" src="https://github.com/yourweather/yourweather-android/assets/94737714/5898f217-e02f-4f6d-a86d-ee14debe990a">
