### PR TITLE
[fix/#540] : 화면 상단 부분 material3 디자인 기반으로 상단바 TAB으로 수정

### DIFF
--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/UnwrittenDetailListActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/UnwrittenDetailListActivity.kt
@@ -25,7 +25,8 @@ class UnwrittenDetailListActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        binding.rlBtn1.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabTabUnwrittenList.setNavigationOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageAlarmActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageAlarmActivity.kt
@@ -30,12 +30,11 @@ class MyPageAlarmActivity : AppCompatActivity() {
         binding = ActivityMyPageAlarmBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.btnAlarmBack.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabTabSetAlarm.setNavigationOnClickListener {
             finish()
         }
-        binding.flMypageAlarmBackbtn.setOnClickListener {
-            finish()
-        }
+
 
 
         val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageMyInfoActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageMyInfoActivity.kt
@@ -29,13 +29,11 @@ class MyPageMyInfoActivity : AppCompatActivity() {
         binding = ActivityMyInfoBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.flMyinfoBackbtn.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabTabMyInfo.setNavigationOnClickListener {
             finish()
         }
 
-        binding.btnMyinfoBack.setOnClickListener {
-            finish()
-        }
 
         binding.btnMyinfoPwChange.setOnClickListener {
             val mIntent = Intent(this, MyPagePwChangeActivity::class.java)

--- a/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageNicknameChangeActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageNicknameChangeActivity.kt
@@ -36,7 +36,8 @@ class MyPageNicknameChangeActivity : AppCompatActivity() {
 
         }
 
-        binding.flMypageNicknameBackbtn.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.topAppBar.setNavigationOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageNicknameChangeActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageNicknameChangeActivity.kt
@@ -33,11 +33,10 @@ class MyPageNicknameChangeActivity : AppCompatActivity() {
         binding.btnMypageNicknameRefresh.setOnClickListener {
             binding.etMypageNicknameNickname.setText("")
             binding.etMypageNicknameNickname.hint = NicknameUtils.getRandomHintText()
-
         }
 
         // topAppBar 뒤로가기 누른 경우
-        binding.topAppBar.setNavigationOnClickListener {
+        binding.tabNicknameChange.setNavigationOnClickListener {
             finish()
         }
 
@@ -65,7 +64,7 @@ class MyPageNicknameChangeActivity : AppCompatActivity() {
         val newNickname = binding.etMypageNicknameNickname.text.toString()
         if (newNickname.isNotEmpty()) {
             performNicknameChange(newNickname)
-        } else if(newNickname.isBlank()) {
+        } else if (newNickname.isBlank()) {
             // 닉네임이 비어있는 경우 처리
             val hintNickname = binding.etMypageNicknameNickname.hint.toString()
             performNicknameChange(hintNickname)

--- a/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPagePwChangeActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPagePwChangeActivity.kt
@@ -28,7 +28,8 @@ class MyPagePwChangeActivity : AppCompatActivity() {
         binding = ActivityMyPagePwChangeBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.flMypagePwBackbtn.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabTabPwChange.setNavigationOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/FindPwEmailActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/FindPwEmailActivity.kt
@@ -59,11 +59,8 @@ class FindPwEmailActivity : AppCompatActivity() {
             resendEmail(email)
         }
 
-        binding.btnFindPwEmailLeftArrow.setOnClickListener {
-            finish()
-        }
-
-        binding.flFinpwEmailBackbtn.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabFindPwEmail.setNavigationOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/ResetPwActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/ResetPwActivity.kt
@@ -41,11 +41,8 @@ class ResetPwActivity : AppCompatActivity() {
             resetPwApi(binding.etResetPwRepw.text.toString())
         }
 
-        binding.btnResetPwLeftArrow.setOnClickListener {
-            finish()
-        }
-
-        binding.flResetPwBackbtn.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabTabPwReset.setNavigationOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp2Activity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp2Activity.kt
@@ -28,13 +28,8 @@ class SignUp2Activity : AppCompatActivity() {
             getPw()
         }
 
-        binding.btnSignup2Back.setOnClickListener {
-            val mIntent = Intent(this, SignUpActivity::class.java)
-            startActivity(mIntent)
-            finish()
-        }
-
-        binding.flSignup2Backbtn.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabTabSignUp2.setNavigationOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignUpActivity.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignUpActivity.kt
@@ -44,14 +44,8 @@ class SignUpActivity : AppCompatActivity() {
         // 아래 동의 문구 글자 색깔 지정해주는 코드
         setAlertText(this@SignUpActivity, binding.root, R.id.tv_signup_alertText)
 
-        // "뒤로 가기" 버튼 클릭 시 이벤트 처리
-        binding.btnSingupBack.setOnClickListener {
-            val mIntent = Intent(this, SignInActivity::class.java)
-            startActivity(mIntent)
-            finish()
-        }
-
-        binding.flSignupBackbtn.setOnClickListener {
+        // topAppBar 뒤로가기 누른 경우
+        binding.tabTabSignUp1.setNavigationOnClickListener {
             finish()
         }
 

--- a/app/src/main/res/drawable/ic_tap_arrow_left_blck_55_56.xml
+++ b/app/src/main/res/drawable/ic_tap_arrow_left_blck_55_56.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="55dp"
+    android:height="56dp"
+    android:viewportWidth="55"
+    android:viewportHeight="56">
+  <path
+      android:pathData="M32,19L27.5,23.5L23,28L32,37"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2B2B2B"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/activity_find_pw_email.xml
+++ b/app/src/main/res/layout/activity_find_pw_email.xml
@@ -6,69 +6,39 @@
     android:layout_height="match_parent"
     tools:context=".presentation.sign.FindPwEmailActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/ll_finpw_email_0"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_find_pw_email"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <FrameLayout
-            android:id="@+id/fl_finpw_email_backbtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:padding="7dp"
-            android:paddingRight="7dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/btn_find_pw_email_left_arrow"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="10dp"
-                android:layout_height="18dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_black_leftarrow_8_16" />
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_finpw_email_title"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_find_pw_email"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="@font/pretendardbold"
-            android:gravity="center"
-            android:text="@string/tv_find_pw_email_title"
-            android:textColor="@color/sorange"
-            android:textSize="20dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
 
+            <TextView
+                android:id="@+id/tv_tab_find_pw_email"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_find_pw_email"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.appbar.MaterialToolbar>
 
-    <TextView
-        android:id="@+id/tv_find_pw_email_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/tv_find_pw_email_title"
-        android:textColor="@color/sorange"
-        android:textSize="20dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginBottom="16dp"
-        android:layout_marginTop="16dp"
-        android:fontFamily="@font/pretendardbold"/>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <TextView
         android:id="@+id/tv_findpw_email_context"
@@ -83,7 +53,7 @@
         android:textSize="18dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ll_finpw_email_0" />
+        app:layout_constraintTop_toBottomOf="@+id/bnv_tab_find_pw_email" />
 
     <TextView
         android:id="@+id/tv_find_pw_user_email"

--- a/app/src/main/res/layout/activity_my_info.xml
+++ b/app/src/main/res/layout/activity_my_info.xml
@@ -8,52 +8,40 @@
     android:id="@+id/total_View">
 
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_myinfo_title"
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_my_info"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <FrameLayout
-            android:id="@+id/fl_myinfo_backbtn"
-            android:layout_width="56dp"
-            android:layout_height="58dp"
-            android:padding="7dp"
-            android:paddingRight="7dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/btn_myinfo_back"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="10dp"
-                android:layout_height="18dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_black_leftarrow_8_16" />
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_signup_title"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_tab_my_info"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="@font/pretendardbold"
-            android:gravity="center"
-            android:text="@string/tv_myinfo_title"
-            android:textColor="@color/sorange"
-            android:textSize="20dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
+
+            <TextView
+                android:id="@+id/tv_tab_my_info"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_my_info"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
 
     <LinearLayout
@@ -66,7 +54,7 @@
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/cl_myinfo_title">
+        app:layout_constraintTop_toBottomOf="@+id/bnv_tab_my_info">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_my_page_alarm.xml
+++ b/app/src/main/res/layout/activity_my_page_alarm.xml
@@ -6,37 +6,39 @@
     android:layout_height="match_parent"
     tools:context=".presentation.mypage.MyPageAlarmActivity">
 
-    <FrameLayout
-        android:id="@+id/fl_mypage_alarm_backbtn"
-        android:layout_width="46dp"
-        android:layout_height="49dp"
-        android:padding="7dp"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_set_alarm"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ImageButton
-            android:id="@+id/btn_alarm_back"
-            style="?android:attr/borderlessButtonStyle"
-            android:layout_width="10dp"
-            android:layout_height="18dp"
-            android:layout_gravity="center"
-            android:background="@drawable/ic_black_leftarrow_8_16" />
-    </FrameLayout>
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_tab_set_alarm"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
 
-    <TextView
-        android:id="@+id/tv_my_alarm_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:fontFamily="@font/pretendardbold"
-        android:gravity="center"
-        android:text="@string/tv_my_alarm_title"
-        android:textAlignment="center"
-        android:textColor="#F07818"
-        android:textSize="20sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginTop="12dp" />
+            <TextView
+                android:id="@+id/tv_tab_set_alarm"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_set_alarm"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <TextView
         android:id="@+id/tv_my_alarm_weekly"
@@ -47,7 +49,7 @@
         android:fontFamily="@font/pretendardsemibold"
         android:layout_marginStart="35dp"
         android:layout_marginTop="60dp"
-        app:layout_constraintTop_toBottomOf="@id/tv_my_alarm_title"
+        app:layout_constraintTop_toBottomOf="@id/bnv_tab_set_alarm"
         app:layout_constraintStart_toStartOf="parent"
         />
 
@@ -57,7 +59,7 @@
         android:layout_height="wrap_content"
         android:fontFamily="@font/pretendardsemibold"
         tools:ignore="UseSwitchCompatOrMaterialXml"
-        app:layout_constraintTop_toBottomOf="@id/tv_my_alarm_title"
+        app:layout_constraintTop_toBottomOf="@id/bnv_tab_set_alarm"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginEnd="33dp"
         android:layout_marginTop="63dp"
@@ -72,7 +74,7 @@
         android:background="#ECECEC"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_my_alarm_title"
+        app:layout_constraintTop_toBottomOf="@id/bnv_tab_set_alarm"
         android:layout_marginTop="110dp"
         android:layout_marginStart="33dp"
         android:layout_marginEnd="24dp"/>

--- a/app/src/main/res/layout/activity_my_page_nickname_change.xml
+++ b/app/src/main/res/layout/activity_my_page_nickname_change.xml
@@ -6,53 +6,39 @@
     android:layout_height="match_parent"
     tools:context=".presentation.mypage.MyPageNicknameChangeActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_mypage_nickname_title"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <FrameLayout
-            android:id="@+id/fl_mypage_nickname_backbtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:padding="7dp"
-            android:paddingRight="7dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/btn_singup_back"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="10dp"
-                android:layout_height="18dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_black_leftarrow_8_16" />
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_mypage_nickname_title"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/topAppBar"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="@font/pretendardbold"
-            android:gravity="center"
-            android:text="@string/tv_mypage_nickname_title"
-            android:textColor="@color/sorange"
-            android:textSize="20dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="닉네임 변경"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
 
     <TextView
         android:id="@+id/tv_mypage_nickname_guide"
@@ -68,7 +54,7 @@
         android:textSize="15dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/cl_mypage_nickname_title" />
+        app:layout_constraintTop_toBottomOf="@+id/bnv_topAppBar" />
 
     <FrameLayout
         android:id="@+id/fl_mypage_nickname"

--- a/app/src/main/res/layout/activity_my_page_nickname_change.xml
+++ b/app/src/main/res/layout/activity_my_page_nickname_change.xml
@@ -7,7 +7,7 @@
     tools:context=".presentation.mypage.MyPageNicknameChangeActivity">
 
     <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/bnv_topAppBar"
+        android:id="@+id/bnv_tab_nickname_change"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -15,7 +15,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/topAppBar"
+            android:id="@+id/tab_nickname_change"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/white"
@@ -26,11 +26,12 @@
             app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
 
             <TextView
+                android:id="@+id/tv_nickname_change_tab_title"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
                 android:fontFamily="@font/pretendardbold"
-                android:text="닉네임 변경"
+                android:text="@string/tv_nickname_change_tab_title"
                 android:textAlignment="center"
                 android:textColor="@color/sorange"
                 android:textSize="18dp" />
@@ -54,7 +55,7 @@
         android:textSize="15dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/bnv_topAppBar" />
+        app:layout_constraintTop_toBottomOf="@+id/bnv_tab_nickname_change" />
 
     <FrameLayout
         android:id="@+id/fl_mypage_nickname"

--- a/app/src/main/res/layout/activity_my_page_pw_change.xml
+++ b/app/src/main/res/layout/activity_my_page_pw_change.xml
@@ -6,53 +6,39 @@
     android:layout_height="match_parent"
     tools:context=".presentation.mypage.MyPagePwChangeActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_mypage_nickname_title"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_pw_change"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <FrameLayout
-            android:id="@+id/fl_mypage_pw_backbtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:padding="7dp"
-            android:paddingRight="7dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/btn_singup_back"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="10dp"
-                android:layout_height="18dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_black_leftarrow_8_16" />
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_mypage_pw_title"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_tab_pw_change"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="@font/pretendardbold"
-            android:gravity="center"
-            android:text="@string/tv_mypage_pw_title"
-            android:textColor="@color/sorange"
-            android:textSize="20dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
+
+            <TextView
+                android:id="@+id/tv_tab_pw_change"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_pw_change"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <TextView
         android:id="@+id/tv_mypage_pw_mypw"
@@ -68,7 +54,7 @@
         android:visibility="visible"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/cl_mypage_nickname_title" />
+        app:layout_constraintTop_toBottomOf="@+id/bnv_tab_pw_change" />
 
 
     <FrameLayout

--- a/app/src/main/res/layout/activity_pw_reset.xml
+++ b/app/src/main/res/layout/activity_pw_reset.xml
@@ -6,55 +6,39 @@
     android:layout_height="match_parent"
     tools:context=".presentation.sign.ResetPwActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/ll_reset_pw_email_0"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_pw_reset"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <FrameLayout
-            android:id="@+id/fl_reset_pw_backbtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:padding="7dp"
-            android:paddingRight="7dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/btn_reset_pw_left_arrow"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="10dp"
-                android:layout_height="18dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_black_leftarrow_8_16" />
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_pw_reset_title"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_tab_pw_reset"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="@font/pretendardbold"
-            android:gravity="center"
-            android:text="비밀번호 재설정"
-            android:textColor="@color/sorange"
-            android:textSize="20dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
 
+            <TextView
+                android:id="@+id/tv_tab_pw_reset"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_pw_reset"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <TextView
         android:id="@+id/tv_reset_pw_guide1"
@@ -72,7 +56,7 @@
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ll_reset_pw_email_0" />
+        app:layout_constraintTop_toBottomOf="@+id/bnv_tab_pw_reset" />
 
     <FrameLayout
         android:id="@+id/frameLayout_reset_pw"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -6,55 +6,39 @@
     android:layout_height="match_parent"
     tools:context=".presentation.sign.SignUpActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/ll_singup0"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_sign_up1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <FrameLayout
-            android:id="@+id/fl_signup_backbtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:padding="7dp"
-            android:paddingRight="7dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/btn_singup_back"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="10dp"
-                android:layout_height="18dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_black_leftarrow_8_16" />
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_signup_title"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_tab_sign_up1"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="@font/pretendardbold"
-            android:gravity="center"
-            android:text="@string/tv_signup_title"
-            android:textColor="@color/sorange"
-            android:textSize="20dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
 
+            <TextView
+                android:id="@+id/tv_tab_sign_up1"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_sign_up1"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
 
     <TextView
@@ -73,7 +57,7 @@
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ll_singup0" />
+        app:layout_constraintTop_toBottomOf="@+id/bnv_tab_sign_up1" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/textinput_signup_1"

--- a/app/src/main/res/layout/activity_sign_up2.xml
+++ b/app/src/main/res/layout/activity_sign_up2.xml
@@ -5,55 +5,39 @@
     android:layout_height="match_parent"
     tools:context=".presentation.sign.SignUp2Activity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/ll_singin2_0"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_sign_up2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <FrameLayout
-            android:id="@+id/fl_signup2_backbtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:padding="7dp"
-            android:paddingRight="7dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/btn_signup2_back"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="10dp"
-                android:layout_height="18dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_black_leftarrow_8_16" />
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_signup2_title"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_tab_sign_up2"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="@font/pretendardbold"
-            android:gravity="center"
-            android:text="@string/tv_signup_title"
-            android:textColor="@color/sorange"
-            android:textSize="20dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
 
+            <TextView
+                android:id="@+id/tv_tab_sign_up2"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_sign_up1"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <TextView
         android:id="@+id/tv_signup2_pw"

--- a/app/src/main/res/layout/activity_unwritten_detail_list.xml
+++ b/app/src/main/res/layout/activity_unwritten_detail_list.xml
@@ -8,50 +8,51 @@
     tools:context=".presentation.analysis.UnwrittenDetailListActivity">
 
 
-    <RelativeLayout
-        android:id="@+id/rl_btn1"
-        android:layout_width="44dp"
-        android:layout_height="52dp"
+
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/bnv_tab_unwritten_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ImageButton
-            android:id="@+id/btn_Unwritten_left_arrow"
-            style="?android:attr/borderlessButtonStyle"
-            android:layout_width="10dp"
-            android:layout_height="18dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="19dp"
-            android:background="@drawable/ic_black_leftarrow_8_16"
-            android:paddingTop="10dp"
-            app:layout_constraintHeight_percent="0.05"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-    </RelativeLayout>
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tab_tab_unwritten_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:clickable="true"
+            android:minHeight="?attr/actionBarSize"
+            android:textAlignment="center"
+            app:menu="@menu/memu_appbar_back"
+            app:navigationIcon="@drawable/ic_tap_arrow_left_blck_55_56">
 
-    <TextView
-        android:id="@+id/tv_Unwritten_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:fontFamily="@font/bmhanna"
-        android:text="@string/tv_Unwritten_title"
-        android:textColor="@color/sorange"
-        android:textSize="20dp"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+            <TextView
+                android:id="@+id/tv_tab_unwritten_list"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:fontFamily="@font/pretendardbold"
+                android:text="@string/tv_tab_unwritten_list"
+                android:textAlignment="center"
+                android:textColor="@color/sorange"
+                android:textSize="18dp" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewUnwrittenDetail"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="64dp"
+        android:layout_marginTop="30dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tv_Unwritten_title"
+        app:layout_constraintTop_toBottomOf="@+id/bnv_tab_unwritten_list"
         tools:listitem="@layout/item_unwritten_detail" />
 
 

--- a/app/src/main/res/menu/memu_appbar_back.xml
+++ b/app/src/main/res/menu/memu_appbar_back.xml
@@ -2,13 +2,5 @@
 <menu xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item
-        android:id="@+id/memu_appbar_backbtn"
-        android:icon="@drawable/ic_black_leftarrow_8_16"
-        android:title="memu_appbar_backbtn"
-        app:showAsAction="always" />
-    <item
-        android:id="@+id/memu_appbar_title"
-        android:title="memu_appbar_title"
-        app:showAsAction="always" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,5 @@
     <string name="tv_withdraw_withdraw">회원 탈퇴</string>
     <string name="tv_ok">확인</string>
     <string name="tv_nickname_change_tab_title">닉네임 변경</string>
+    <string name="tv_tab_sign_up1">회원가입</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,5 @@
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="tv_withdraw_withdraw">회원 탈퇴</string>
     <string name="tv_ok">확인</string>
+    <string name="tv_nickname_change_tab_title">닉네임 변경</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,6 @@
     <string name="tv_nickname_change_tab_title">닉네임 변경</string>
     <string name="tv_tab_sign_up1">회원가입</string>
     <string name="tv_tab_pw_reset">비밀번호 재설정</string>
+    <string name="tv_tab_find_pw_email">이메일 본인 인증</string>
+    <string name="tv_tab_unwritten_list">미입력 내역</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,7 @@
     <string name="tv_tab_pw_reset">비밀번호 재설정</string>
     <string name="tv_tab_find_pw_email">이메일 본인 인증</string>
     <string name="tv_tab_unwritten_list">미입력 내역</string>
+    <string name="tv_tab_my_info">내 정보</string>
+    <string name="tv_tab_pw_change">비밀번호 변경</string>
+    <string name="tv_tab_set_alarm">알림 설정</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,4 +38,5 @@
     <string name="tv_ok">확인</string>
     <string name="tv_nickname_change_tab_title">닉네임 변경</string>
     <string name="tv_tab_sign_up1">회원가입</string>
+    <string name="tv_tab_pw_reset">비밀번호 재설정</string>
 </resources>


### PR DESCRIPTION
## 개요

> closed #540 

## 작업 사항

- [x]  하나하나 컴포넌트로 있던 화면 상단 부분 material3 디자인 기반으로 상단바 TAB으로 수정하였습니다.

## 참고사항 및 스크린샷
![image](https://github.com/yourweather/yourweather-android/assets/83583757/7f3bf6e6-e98c-4ad3-8e76-221e6a88bae6)

## to reviewer
시간관계상.. hotfix로 뒤로가기 버튼 있는 부분의 상단바만 우선 구현했고 
나머지도 최대한 빠르게 쇽샥 하겠습니다
위의 사진에서 라벨 붙어져 있는 것들을 **제외한** 나머지 상단바만 해당 pr에 수정되어 반영되었습니다.'
클릭 시 뒤로 가는 로직도 구현 완료되었고, 빌드 후 확인까지 했습니다.